### PR TITLE
fix: Implicit publishing triggered by CI detection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro:build": "astro build",
     "astro:preview": "astro preview",
     "electron:dev": "concurrently \"astro dev\" \"wait-on http://localhost:4321 && electron .\"",
-    "electron:build": "astro build && electron-builder",
+    "electron:build": "astro build && electron-builder --publish never",
     "lint": "eslint .",
     "typecheck": "astro check && tsc --noEmit"
   },


### PR DESCRIPTION
* Updated the `electron:build` script to include `--publish never` with `electron-builder`, ensuring that builds are not automatically published.