### PR TITLE
fix: EUSAGE errors and update CI build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 24
           cache: "npm"
-      - run: npm ci
+      - run: npm install
       - run: npx vue-tsc --noEmit
 
   codeql:
@@ -61,7 +61,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run electron:build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,10 +64,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run electron:build
-
-      - name: Prune dev dependencies
-        run: npm prune --production
+        run: npm run build
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Replaced `npm ci` with `npm install` for installing dependencies in both jobs.
* Changed the build command in the codeql job from `npm run electron:build` to `npm run build`.
* Removed the step that prunes dev dependencies (`npm prune --production`) from the codeql job.