### PR TITLE
ci: Upload .exe files separately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,3 +71,9 @@ jobs:
         with:
           name: re-color
           path: release/
+      
+      - name: Upload Executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: re-color-exe
+          path: release/**/*.exe


### PR DESCRIPTION
* Added a new "Upload Executables" step to `.github/workflows/main.yml` that uses `actions/upload-artifact@v4` to upload all `.exe` files from the `release` directory.