### PR TITLE
refactor: Use @ path alias; update imports and configs

### DIFF
--- a/src/components/ColorBar.vue
+++ b/src/components/ColorBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useColorStore, PALETTE } from "../stores/useColorStore";
+import { useColorStore, PALETTE } from "@/stores/useColorStore";
 import colorNamer from "color-namer";
 const colorStore = useColorStore();
 </script>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useCanvasStore } from "../stores/useCanvasStore";
-import { useColorStore } from "../stores/useColorStore";
+import { useCanvasStore } from "@/stores/useCanvasStore";
+import { useColorStore } from "@/stores/useColorStore";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -1,46 +1,47 @@
 <script setup lang="ts">
-import { useCanvasStore, type Tool } from "../stores/useCanvasStore";
+import { useCanvasStore, type Tool } from "@/stores/useCanvasStore";
 import type { Component } from "vue";
-import BrushIcon from "../assets/brush-tool.svg?component";
-import EraserIcon from "../assets/eraser-tool.svg?component";
-import LineIcon from "../assets/line-tool.svg?component";
-import RectIcon from "../assets/rect-tool.svg?component";
-import CircleIcon from "../assets/circle-tool.svg?component";
+import BrushIcon from "@/assets/brush-tool.svg?component";
+import EraserIcon from "@/assets/eraser-tool.svg?component";
+import LineIcon from "@/assets/line-tool.svg?component";
+import RectIcon from "@/assets/rect-tool.svg?component";
+import CircleIcon from "@/assets/circle-tool.svg?component";
 
 const store = useCanvasStore();
 
-const tools: { id: Tool; label: string; shortcut: string; icon: Component }[] = [
-	{
-		id: "brush",
-		label: "Brush",
-		shortcut: "B",
-		icon: BrushIcon,
-	},
-	{
-		id: "eraser",
-		label: "Eraser",
-		shortcut: "E",
-		icon: EraserIcon,
-	},
-	{
-		id: "line",
-		label: "Line",
-		shortcut: "L",
-		icon: LineIcon,
-	},
-	{
-		id: "rect",
-		label: "Rect",
-		shortcut: "R",
-		icon: RectIcon,
-	},
-	{
-		id: "circle",
-		label: "Circle",
-		shortcut: "C",
-		icon: CircleIcon,
-	},
-];
+const tools: { id: Tool; label: string; shortcut: string; icon: Component }[] =
+	[
+		{
+			id: "brush",
+			label: "Brush",
+			shortcut: "B",
+			icon: BrushIcon,
+		},
+		{
+			id: "eraser",
+			label: "Eraser",
+			shortcut: "E",
+			icon: EraserIcon,
+		},
+		{
+			id: "line",
+			label: "Line",
+			shortcut: "L",
+			icon: LineIcon,
+		},
+		{
+			id: "rect",
+			label: "Rect",
+			shortcut: "R",
+			icon: RectIcon,
+		},
+		{
+			id: "circle",
+			label: "Circle",
+			shortcut: "C",
+			icon: CircleIcon,
+		},
+	];
 </script>
 
 <template>

--- a/src/lib/useKeyboardShortcuts.ts
+++ b/src/lib/useKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import type { useCanvasStore } from "../stores/useCanvasStore";
+import type { useCanvasStore } from "@/stores/useCanvasStore";
 
 type CanvasStore = ReturnType<typeof useCanvasStore>;
 

--- a/src/lib/useTools.ts
+++ b/src/lib/useTools.ts
@@ -1,6 +1,6 @@
 import Konva from "konva";	
-import type { useCanvasStore } from "../stores/useCanvasStore";
-import type { useColorStore } from "../stores/useColorStore";
+import type { useCanvasStore } from "@/stores/useCanvasStore";
+import type { useColorStore } from "@/stores/useColorStore";
 
 type CanvasStore = ReturnType<typeof useCanvasStore>;
 type ColorStore = ReturnType<typeof useColorStore>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
 import App from "./App.vue";
-import "./style.css";
+import "@/style.css";
 
 const app = createApp(App);
 app.use(createPinia());

--- a/src/views/DrawingArea.vue
+++ b/src/views/DrawingArea.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from "vue";
-import Toolbar from "../components/ToolBar.vue";
-import ColorBar from "../components/ColorBar.vue";
-import StatusBar from "../components/StatusBar.vue";
-import { useCanvasStore } from "../stores/useCanvasStore";
-import { useColorStore } from "../stores/useColorStore";
-import { useStage } from "../lib/useStage";
-import { useTools } from "../lib/useTools";
-import { useKeyboardShortcuts } from "../lib/useKeyboardShortcuts";
+import Toolbar from "@/components/ToolBar.vue";
+import ColorBar from "@/components/ColorBar.vue";
+import StatusBar from "@/components/StatusBar.vue";
+import { useCanvasStore } from "@/stores/useCanvasStore";
+import { useColorStore } from "@/stores/useColorStore";
+import { useStage } from "@/lib/useStage";
+import { useTools } from "@/lib/useTools";
+import { useKeyboardShortcuts } from "@/lib/useKeyboardShortcuts";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,14 +1,17 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "types": ["vite/client"],
+	"extends": "@vue/tsconfig/tsconfig.dom.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"types": ["vite/client"],
+		"paths": {
+			"@/*": ["./src/*"]
+		},
 
-    /* Linting */
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+		/* Linting */
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 	],
 	"compilerOptions": {
 		"paths": {
-			"@components/*": ["./src/conponents/*"]
+			"@/*": ["./src/*"]
 		}
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import svgLoader from "vite-svg-loader";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
 	base: "./",
 	plugins: [vue(), tailwindcss(), svgLoader()],
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+		},
+	},
 });


### PR DESCRIPTION
- Replaced relative imports with the `@/...` path alias across components, libs and css files. 
- Added TypeScript path mapping to map `@/*` to `./src/*`. 
- Add Vite `resolve.alias` using `path.resolve`.