### PR TITLE
feat: Show DevTools in development

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ function createWindow() {
 			label: "View",
 			submenu: [
 				{ role: "reload" },
+				...(!app.isPackaged ? [{ role: "toggleDevTools" }] : []),
 				{ type: "separator" },
 				{ role: "resetZoom" },
 				{ role: "zoomIn" },


### PR DESCRIPTION
* Conditionally adds the `{ role: "toggleDevTools" }` menu item to the "View" submenu only if the app is not packaged.