### PR TITLE
feat: Add dichromacy simulation filters to color picker and UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mark Jerwin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,45 @@
 		<title>Re:Color</title>
 	</head>
 	<body>
+		<!-- This filter is based of Machado, Gustavo & Oliveira, Manuel & Fernandes, Leandro. (2009). A
+		Physiologically-Based Model for Simulation of Color Vision Deficiency (vol
+		15, pg 1291, 2009). IEEE transactions on visualization and computer
+		graphics. 15. 1291-8. 10.1109/TVCG.2009.113. -->
+		<svg style="display: none" xmlns="http://www.w3.org/2000/svg">
+			<defs>
+				<filter id="deuteranopia">
+					<feColorMatrix
+						type="matrix"
+						values="
+          0.367  0.861 -0.228  0  0
+          0.280  0.673  0.047  0  0
+         -0.012  0.043  0.969  0  0
+          0      0      0      1  0"
+					/>
+				</filter>
+				<filter id="protanopia">
+					<feColorMatrix
+						type="matrix"
+						values="
+          0.152  1.053 -0.205  0  0
+          0.115  0.786  0.099  0  0
+         -0.004 -0.048  1.052  0  0
+          0      0      0      1  0"
+					/>
+				</filter>
+				<filter id="tritanopia">
+					<feColorMatrix
+						type="matrix"
+						values="
+          1.256 -0.077 -0.179  0  0
+         -0.078  0.931  0.148  0  0
+          0.005  0.691  0.304  0  0
+          0      0      0      1  0"
+					/>
+				</filter>
+			</defs>
+		</svg>
+
 		<div id="app"></div>
 		<script type="module" src="/src/main.ts"></script>
 	</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "re-color",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "re-color",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
+				"@simonwep/pickr": "^1.9.1",
 				"color-namer": "^1.4.0",
 				"konva": "^9.3.6",
 				"pinia": "^2.1.7",
@@ -56,9 +57,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.0"
@@ -471,6 +472,7 @@
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cross-dirname": "^0.1.0",
 				"debug": "^4.3.4",
@@ -492,6 +494,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -508,6 +511,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -522,6 +526,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -533,7 +538,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
@@ -546,7 +550,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -1018,6 +1021,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1035,6 +1041,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1052,6 +1061,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1069,6 +1081,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1086,6 +1101,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1103,6 +1121,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1188,6 +1209,16 @@
 			"integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@simonwep/pickr": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.9.1.tgz",
+			"integrity": "sha512-fR3qmfAcPf/HSFS7GEnTmZLM3+xERv1+jyMBbzT63ilRRM8veYjI7ELvkHHKk0/du3lHp7uh/FqatjM3646X1g==",
+			"license": "MIT",
+			"dependencies": {
+				"core-js": "3.37.0",
+				"nanopop": "2.4.2"
+			}
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
@@ -1348,6 +1379,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1365,6 +1399,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1382,6 +1419,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1399,6 +1439,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1679,7 +1722,6 @@
 			"integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.1",
 				"@typescript-eslint/types": "8.59.1",
@@ -2110,7 +2152,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2144,7 +2185,6 @@
 			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2867,6 +2907,17 @@
 				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "3.37.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+			"integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2892,7 +2943,8 @@
 			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3418,9 +3470,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "41.3.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
-			"integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
+			"version": "41.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
+			"integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3575,6 +3627,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@electron/asar": "^3.2.1",
 				"debug": "^4.1.1",
@@ -3595,6 +3648,7 @@
 			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -3803,7 +3857,6 @@
 			"integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
@@ -5082,6 +5135,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5103,6 +5159,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5124,6 +5183,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5145,6 +5207,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5387,6 +5452,7 @@
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.6"
 			},
@@ -5409,9 +5475,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -5425,6 +5491,12 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
+		},
+		"node_modules/nanopop": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/nanopop/-/nanopop-2.4.2.tgz",
+			"integrity": "sha512-NzOgmMQ+elxxHeIha+OG/Pv3Oc3p4RU2aBhwWwAqDpXrdTbtRylbRLQztLy8dMMwfl6pclznBdfUhccEn9ZIzw==",
+			"license": "MIT"
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -5754,7 +5826,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5800,9 +5871,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"version": "8.5.13",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+			"integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5848,6 +5919,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"commander": "^9.4.0"
 			},
@@ -5865,6 +5937,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.20.0 || >=14"
 			}
@@ -5885,7 +5958,6 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6133,6 +6205,7 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -6564,6 +6637,7 @@
 			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
@@ -6757,7 +6831,6 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6863,7 +6936,6 @@
 			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -6962,7 +7034,6 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
 			"integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.33",
 				"@vue/compiler-sfc": "3.5.33",
@@ -7011,6 +7082,7 @@
 			"integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"eslint-scope": "^8.2.0 || ^9.0.0",
@@ -7035,6 +7107,7 @@
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		}
 	},
 	"dependencies": {
+		"@simonwep/pickr": "^1.9.1",
 		"color-namer": "^1.4.0",
 		"konva": "^9.3.6",
 		"pinia": "^2.1.7",

--- a/src/components/ColorBar.vue
+++ b/src/components/ColorBar.vue
@@ -1,7 +1,45 @@
 <script setup lang="ts">
+import { onMounted, onUnmounted, watch, ref } from "vue";
 import { useColorStore, PALETTE } from "../stores/useColorStore";
+import Pickr from "@simonwep/pickr";
 import colorNamer from "color-namer";
+
 const colorStore = useColorStore();
+
+const pickrRef = ref<HTMLDivElement>();
+let pickr: Pickr | null = null;
+
+onMounted(() => {
+	pickr = Pickr.create({
+		el: pickrRef.value!,
+		theme: "nano",
+		default: colorStore.activeColor,
+		components: {
+			preview: true,
+			hue: true,
+			interaction: {
+				hex: false,
+				input: true,
+				save: false,
+			},
+		},
+	});
+
+	pickr.on("change", (color: Pickr.HSVaColor) => {
+		const hex = color.toHEXA().toString().slice(0, 7);
+		colorStore.setColor(hex);
+		pickr?.applyColor();
+	});
+});
+
+watch(
+	() => colorStore.activeColor,
+	(hex) => {
+		pickr!.setColor(hex);
+	},
+);
+
+onUnmounted(() => pickr?.destroyAndRemove());
 </script>
 
 <template>
@@ -12,14 +50,7 @@ const colorStore = useColorStore();
 			class="flex items-center gap-2.5"
 			:style="{ filter: colorStore.cssFilter }"
 		>
-			<input
-				id="custom-color-picker"
-				title="Custom Color Picker"
-				type="color"
-				:value="colorStore.activeColor"
-				@input="colorStore.setColor(($event.target as HTMLInputElement).value)"
-				class="h-10 w-10 cursor-pointer"
-			/>
+			<div ref="pickrRef"></div>
 
 			<div id="swatch-bar" class="flex flex-wrap items-center gap-1">
 				<button
@@ -30,8 +61,8 @@ const colorStore = useColorStore();
 					:class="[
 						'h-6 w-6 cursor-pointer border-2 transition-all duration-100',
 						colorStore.activeColor.toLowerCase() === color.hex.toLowerCase()
-							? 'border-highlight scale-110'
-							: 'border-transparent hover:scale-110 hover:border-white/40',
+							? 'scale-105 border-white/50'
+							: 'border-transparent hover:scale-105 hover:border-white/40',
 					]"
 					:style="{ background: color.hex }"
 				></button>

--- a/src/components/ColorBar.vue
+++ b/src/components/ColorBar.vue
@@ -6,31 +6,36 @@ const colorStore = useColorStore();
 
 <template>
 	<div
-		class="bg-panel border-accent flex items-center gap-2.5 border-t  py-1 px-2"
+		class="bg-panel border-accent flex items-center gap-2.5 border-t px-2 py-1"
 	>
-		<input
-			id="custom-color-picker"
-			title="Custom Color Picker"
-			type="color"
-			:value="colorStore.activeColor"
-			@input="colorStore.setColor(($event.target as HTMLInputElement).value)"
-			class="h-10 w-10 cursor-pointer"
-		/>
+		<div
+			class="flex items-center gap-2.5"
+			:style="{ filter: colorStore.cssFilter }"
+		>
+			<input
+				id="custom-color-picker"
+				title="Custom Color Picker"
+				type="color"
+				:value="colorStore.activeColor"
+				@input="colorStore.setColor(($event.target as HTMLInputElement).value)"
+				class="h-10 w-10 cursor-pointer"
+			/>
 
-		<div class="flex flex-wrap items-center gap-1">
-			<button
-				v-for="color in PALETTE"
-				:key="color.hex"
-				@click="colorStore.setColor(color.hex)"
-				:title="colorNamer(color.hex).ntc[0].name + ' (' + color.hex + ')'"
-				:class="[
-					'h-6 w-6 cursor-pointer border-2 transition-all duration-100',
-					colorStore.activeColor.toLowerCase() === color.hex.toLowerCase()
-						? 'border-highlight scale-110'
-						: 'border-transparent hover:scale-110 hover:border-white/40',
-				]"
-				:style="{ background: color.hex }"
-			></button>
+			<div id="swatch-bar" class="flex flex-wrap items-center gap-1">
+				<button
+					v-for="color in PALETTE"
+					:key="color.hex"
+					@click="colorStore.setColor(color.hex)"
+					:title="colorNamer(color.hex).ntc[0].name + ' (' + color.hex + ')'"
+					:class="[
+						'h-6 w-6 cursor-pointer border-2 transition-all duration-100',
+						colorStore.activeColor.toLowerCase() === color.hex.toLowerCase()
+							? 'border-highlight scale-110'
+							: 'border-transparent hover:scale-110 hover:border-white/40',
+					]"
+					:style="{ background: color.hex }"
+				></button>
+			</div>
 		</div>
 	</div>
 </template>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useCanvasStore } from "../stores/useCanvasStore";
-import { useColorStore } from "../stores/useColorStore";
+import { useColorStore, type ColorblindMode } from "../stores/useColorStore";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();
@@ -18,11 +18,38 @@ const colorStore = useColorStore();
 			<p>{{ colorStore.colorName }}</p>
 		</div>
 
-		<div v-if="canvasStore.cursorPos" class="flex items-center gap-1 font-mono">
-			<p>X:</p>
-			<p>{{ canvasStore.cursorPos.x }}</p>
-			<p class="ml-1.5">Y:</p>
-			<p>{{ canvasStore.cursorPos.y }}</p>
+		<div class="flex items-center gap-2">
+			<div
+				v-if="canvasStore.cursorPos"
+				class="flex items-center gap-1 font-mono"
+			>
+				<p>X:</p>
+				<p>{{ canvasStore.cursorPos.x }}</p>
+				<p class="ml-1.5">Y:</p>
+				<p>{{ canvasStore.cursorPos.y }}</p>
+			</div>
+			<select
+				:value="colorStore.mode"
+				@change="
+					colorStore.setMode(
+						($event.target as HTMLSelectElement).value as ColorblindMode,
+					)
+				"
+				class="text-xxs cursor-pointer font-semibold tracking-wide outline-none"
+			>
+				<option class="bg-panel text-white" value="normal">
+					Normal Vision
+				</option>
+				<option class="bg-panel text-white" value="deuteranopia">
+					Deuteranopia
+				</option>
+				<option class="bg-panel text-white" value="protanopia">
+					Protanopia
+				</option>
+				<option class="bg-panel text-white" value="tritanopia">
+					Tritanopia
+				</option>
+			</select>
 		</div>
 	</div>
 </template>

--- a/src/stores/useColorStore.ts
+++ b/src/stores/useColorStore.ts
@@ -21,13 +21,41 @@ export const PALETTE = [
 	{ hex: "#7B2D8B" },
 ];
 
+export type ColorblindMode =
+	| "normal"
+	| "deuteranopia"
+	| "protanopia"
+	| "tritanopia";
+
+const CSS_FILTERS: Record<ColorblindMode, string> = {
+	normal: "none",
+	deuteranopia: "url(#deuteranopia)",
+	protanopia: "url(#protanopia)",
+	tritanopia: "url(#tritanopia)",
+};
+
 export const useColorStore = defineStore("color", () => {
 	const activeColor = ref("#000000");
+
+	// Persisted so the user's mode survives app restarts
+	const mode = ref<ColorblindMode>(
+		(localStorage.getItem("colorblindMode") as ColorblindMode) ?? "normal",
+	);
+
+	// color-namer compares the hex against thousands of named colors and returns
+	// the closest match. .ntc[0].name uses the "Name That Color" dataset
 	const colorName = computed(() => colorNamer(activeColor.value).ntc[0].name);
+
+	const cssFilter = computed(() => CSS_FILTERS[mode.value]);
 
 	function setColor(hex: string) {
 		activeColor.value = hex;
 	}
 
-	return { activeColor, colorName, setColor };
+	function setMode(m: ColorblindMode) {
+		mode.value = m;
+		localStorage.setItem("colorblindMode", m);
+	}
+
+	return { activeColor, colorName, mode, cssFilter, setColor, setMode };
 });

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@simonwep/pickr/dist/themes/nano.min.css";
 
 @theme {
 	--color-surface: var(--color-zinc-900);
@@ -16,4 +17,31 @@ body,
 	@apply bg-surface h-full w-full overflow-hidden text-white;
 	font-family: "Segoe UI", system-ui, sans-serif;
 	user-select: none;
+}
+
+.pcr-app {
+	@apply bg-accent filter-none;
+}
+.pcr-app[data-mode="deuteranopia"] {
+	filter: url(#deuteranopia);
+}
+.pcr-app[data-mode="protanopia"] {
+	filter: url(#protanopia);
+}
+.pcr-app[data-mode="tritanopia"] {
+	filter: url(#tritanopia);
+}
+.pcr-palette {
+	@apply rounded-none!;
+}
+.pcr-current-color {
+	@apply border border-white/50;
+}
+.pcr-app .pcr-interaction .pcr-result {
+	@apply bg-surface! text-white/75 ring-0!;
+}
+.pcr-button,
+.pcr-button::before,
+.pcr-button::after {
+	@apply rounded-none! border-white/50 ring-0! hover:scale-105 hover:border-2;
 }

--- a/src/views/DrawingArea.vue
+++ b/src/views/DrawingArea.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from "vue";
-import Toolbar from "../components/ToolBar.vue";
-import ColorBar from "../components/ColorBar.vue";
-import StatusBar from "../components/StatusBar.vue";
 import { useCanvasStore } from "../stores/useCanvasStore";
 import { useColorStore } from "../stores/useColorStore";
 import { useStage } from "../lib/useStage";
 import { useTools } from "../lib/useTools";
 import { useKeyboardShortcuts } from "../lib/useKeyboardShortcuts";
+import Toolbar from "../components/ToolBar.vue";
+import ColorBar from "../components/ColorBar.vue";
+import StatusBar from "../components/StatusBar.vue";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();
@@ -49,7 +49,10 @@ onUnmounted(() => destroy());
 	>
 		<div class="flex min-h-0 flex-1 overflow-hidden">
 			<Toolbar />
-			<div class="relative flex-1 overflow-hidden bg-surface">
+			<div
+				class="bg-surface relative flex-1 overflow-hidden"
+				:style="{ filter: colorStore.cssFilter }"
+			>
 				<div ref="containerRef" class="h-full w-full"></div>
 			</div>
 		</div>

--- a/src/views/DrawingArea.vue
+++ b/src/views/DrawingArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, onMounted, onUnmounted, watch } from "vue";
 import { useCanvasStore } from "../stores/useCanvasStore";
 import { useColorStore } from "../stores/useColorStore";
 import { useStage } from "../lib/useStage";
@@ -36,6 +36,14 @@ onMounted(() => {
 
 	window.electronAPI?.onNewPainting(() => newCanvas());
 });
+
+watch(
+	() => colorStore.mode,
+	(mode) => {
+		document.querySelector(".pcr-app")?.setAttribute("data-mode", mode);
+	},
+	{ immediate: true },
+);
 
 onUnmounted(() => destroy());
 </script>


### PR DESCRIPTION
* Added SVG filters for deuteranopia, protanopia, and tritanopia simulation in `index.html`, and applied these filters to the drawing area and color picker based on the selected mode.
* Introduced a `ColorblindMode` type and persisted the selected mode in local storage via the `useColorStore` store. The mode can be changed from a new dropdown in the `StatusBar.vue` component. 
* Replaced the native `<input type="color">` with the Pickr color picker in `ColorBar.vue`, providing a more advanced and visually consistent color selection tool. 
* Updated color swatch styling for better visual feedback when selecting colors.
* Added an MIT license to the repository.