### PR TITLE
feat: Add the ability to export canvas as image

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
-const { app, BrowserWindow, Menu, ipcMain } = require("electron");
+const { app, BrowserWindow, Menu, ipcMain, dialog } = require("electron");
 const path = require("path");
+const fs = require("fs");
 
 function createWindow() {
 	const win = new BrowserWindow({
@@ -22,8 +23,13 @@ function createWindow() {
 			submenu: [
 				{
 					label: "New",
-					accelerator: "CmdOrCtrl+N",
-					click: () => win.webContents.send("menu:new-painting"),
+					accelerator: "Ctrl+N",
+					click: () => win.webContents.send("menu:new-canvas"),
+				},
+				{
+					label: "Export",
+					accelerator: "Ctrl+S",
+					click: () => win.webContents.send("menu:export"),
 				},
 				{ type: "separator" },
 				{ role: "quit" },
@@ -61,3 +67,13 @@ function createWindow() {
 }
 
 app.whenReady().then(createWindow);
+
+ipcMain.handle("save-image", async (_, dataURL) => {
+	const { filePath, canceled } = await dialog.showSaveDialog({
+		defaultPath: "painting.png",
+		filters: [{ name: "PNG Image", extensions: ["png"] }],
+	});
+	if (canceled || !filePath) return;
+	const base64 = dataURL.replace(/^data:image\/png;base64,/, "");
+	fs.writeFileSync(filePath, Buffer.from(base64, "base64"));
+});

--- a/preload.js
+++ b/preload.js
@@ -2,5 +2,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("electronAPI", {
-	onNewPainting: (callback) => ipcRenderer.on("menu:new-painting", callback),
+	onNewCanvas: (callback) => ipcRenderer.on("menu:new-canvas", callback),
+	onExport: (callback) => ipcRenderer.on("menu:export", callback),
+	saveImage: (dataURL) => ipcRenderer.invoke("save-image", dataURL),
 });

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,5 +1,8 @@
 interface Window {
 	electronAPI?: {
-		onNewPainting: (callback: () => void) => void;
+		onNewCanvas: (callback: () => void) => void;
+		onExport: (callback: () => void) => void;
+		saveImage: (dataURL: string) => Promise<void>;
+		onSetMode: (callback: (mode: string) => void) => void;
 	};
 }

--- a/src/lib/useStage.ts
+++ b/src/lib/useStage.ts
@@ -132,11 +132,37 @@ export function useStage(
 		fitToViewport(width, height);
 	}
 
+	// Exports the canvas as a PNG data URL.
+	// Resets zoom/pan to 1:1 so we can capture the whole canvas,
+	// then restores back the previous zoom/pan.
+	function exportCanvas() {
+		const prevScale = stage.scaleX();
+		const prevPos = stage.position();
+
+		stage.scale({ x: 1, y: 1 });
+		stage.position({ x: 0, y: 0 });
+
+		const dataURL = stage.toDataURL({
+			x: 0,
+			y: 0,
+			width: CANVAS_WIDTH,
+			height: CANVAS_HEIGHT,
+			pixelRatio: 1,
+		});
+
+		stage.scale({ x: prevScale, y: prevScale });
+		stage.position(prevPos);
+		stage.batchDraw();
+
+		return dataURL;
+	}
+
 	return {
 		init,
 		destroy,
 		getPos,
 		newCanvas,
+		exportCanvas,
 		getStage: () => stage,
 		getDrawLayer: () => drawLayer,
 	};

--- a/src/views/DrawingArea.vue
+++ b/src/views/DrawingArea.vue
@@ -15,7 +15,7 @@ const colorStore = useColorStore();
 const rootRef = ref<HTMLDivElement>();
 const containerRef = ref<HTMLDivElement>();
 
-const { init, destroy, getPos, newCanvas, getStage, getDrawLayer } =
+const { init, destroy, getPos, newCanvas, exportCanvas, getStage, getDrawLayer } =
 	useStage(containerRef);
 const { handleMouseDown, handleMouseMove, handleMouseUp } = useTools(
 	getDrawLayer,
@@ -34,7 +34,11 @@ onMounted(() => {
 	stage.on("mousemove touchmove", handleMouseMove);
 	stage.on("mouseup touchend", handleMouseUp);
 
-	window.electronAPI?.onNewPainting(() => newCanvas());
+	window.electronAPI?.onNewCanvas(() => newCanvas());
+	window.electronAPI?.onExport(async () => {
+		const dataURL = exportCanvas();
+		await window.electronAPI?.saveImage(dataURL);
+	});
 });
 
 watch(


### PR DESCRIPTION
This pull request adds an "Export" feature to the application (closing #47), allowing users to save the current canvas as a PNG image. 

<img width="535" height="291" alt="image" src="https://github.com/user-attachments/assets/f56da968-1d3c-4b3e-a2ae-84fe8356d950" />
