### PR TITLE
refactor: Use '@' path alias for imports

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import DrawingArea from "./views/DrawingArea.vue";
+import DrawingArea from "@/views/DrawingArea.vue";
 </script>
 
 <template>

--- a/src/components/ColorBar.vue
+++ b/src/components/ColorBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, watch, ref } from "vue";
-import { useColorStore, PALETTE } from "../stores/useColorStore";
+import { useColorStore, PALETTE } from "@/stores/useColorStore";
 import Pickr from "@simonwep/pickr";
 import colorNamer from "color-namer";
 

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useCanvasStore } from "../stores/useCanvasStore";
-import { useColorStore, type ColorblindMode } from "../stores/useColorStore";
+import { useCanvasStore } from "@/stores/useCanvasStore";
+import { useColorStore, type ColorblindMode } from "@/stores/useColorStore";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { useCanvasStore, type Tool } from "../stores/useCanvasStore";
+import { useCanvasStore, type Tool } from "@/stores/useCanvasStore";
 import type { Component } from "vue";
-import BrushIcon from "../assets/brush-tool.svg?component";
-import EraserIcon from "../assets/eraser-tool.svg?component";
-import LineIcon from "../assets/line-tool.svg?component";
-import RectIcon from "../assets/rect-tool.svg?component";
-import CircleIcon from "../assets/circle-tool.svg?component";
+import BrushIcon from "@/assets/brush-tool.svg?component";
+import EraserIcon from "@/assets/eraser-tool.svg?component";
+import LineIcon from "@/assets/line-tool.svg?component";
+import RectIcon from "@/assets/rect-tool.svg?component";
+import CircleIcon from "@/assets/circle-tool.svg?component";
 
 const store = useCanvasStore();
 

--- a/src/lib/useKeyboardShortcuts.ts
+++ b/src/lib/useKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import type { useCanvasStore } from "../stores/useCanvasStore";
+import type { useCanvasStore } from "@/stores/useCanvasStore";
 
 type CanvasStore = ReturnType<typeof useCanvasStore>;
 

--- a/src/lib/useTools.ts
+++ b/src/lib/useTools.ts
@@ -1,6 +1,6 @@
 import Konva from "konva";	
-import type { useCanvasStore } from "../stores/useCanvasStore";
-import type { useColorStore } from "../stores/useColorStore";
+import type { useCanvasStore } from "@/stores/useCanvasStore";
+import type { useColorStore } from "@/stores/useColorStore";
 
 type CanvasStore = ReturnType<typeof useCanvasStore>;
 type ColorStore = ReturnType<typeof useColorStore>;

--- a/src/views/DrawingArea.vue
+++ b/src/views/DrawingArea.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from "vue";
-import { useCanvasStore } from "../stores/useCanvasStore";
-import { useColorStore } from "../stores/useColorStore";
-import { useStage } from "../lib/useStage";
-import { useTools } from "../lib/useTools";
-import { useKeyboardShortcuts } from "../lib/useKeyboardShortcuts";
-import Toolbar from "../components/ToolBar.vue";
-import ColorBar from "../components/ColorBar.vue";
-import StatusBar from "../components/StatusBar.vue";
+import { useCanvasStore } from "@/stores/useCanvasStore";
+import { useColorStore } from "@/stores/useColorStore";
+import { useStage } from "@/lib/useStage";
+import { useTools } from "@/lib/useTools";
+import { useKeyboardShortcuts } from "@/lib/useKeyboardShortcuts";
+import Toolbar from "@/components/ToolBar.vue";
+import ColorBar from "@/components/ColorBar.vue";
+import StatusBar from "@/components/StatusBar.vue";
 
 const canvasStore = useCanvasStore();
 const colorStore = useColorStore();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,14 +1,17 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "types": ["vite/client"],
+	"extends": "@vue/tsconfig/tsconfig.dom.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"types": ["vite/client"],
+		"paths": {
+			"@/*": ["./src/*"]
+		},
 
-    /* Linting */
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+		/* Linting */
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 	],
 	"compilerOptions": {
 		"paths": {
-			"@components/*": ["./src/conponents/*"]
+			"@": ["./src/*"]
 		}
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import svgLoader from "vite-svg-loader";
+import path from "path/win32";
 
 // https://vite.dev/config/
 export default defineConfig({
 	base: "./",
 	plugins: [vue(), tailwindcss(), svgLoader()],
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+		},
+	},
 });


### PR DESCRIPTION
This pull request refactors the import paths throughout the codebase to use the `@` alias for the `src` directory instead of relative paths. 