### PR TITLE
build: Update installer configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		},
 		"nsis": {
 			"oneClick": false,
-			"artifactName": "${productName}-v${version}-x64.${ext}",
+			"artifactName": "${productName}-v${version}-x64.${ext}"
 		}
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,12 @@
 		},
 		"win": {
 			"target": [
-				"nsis",
-				"portable"
+				"nsis"
 			]
 		},
 		"nsis": {
-			"artifactName": "${productName} ${version}-Setup.${ext}"
-		},
-		"portable": {
-			"artifactName": "${productName} ${version}-Portable.${ext}"
+			"oneClick": false,
+			"artifactName": "${productName}-v${version}-x64.${ext}",
 		}
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
 		},
 		"nsis": {
 			"oneClick": false,
-			"artifactName": "${productName}-v${version}-x64.${ext}"
+			"allowToChangeInstallationDirectory": true,
+			"artifactName": "${productName}-v${version}-x64.${ext}",
+			"license": "LICENSE"
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
* Removed the `portable` build target. Only the NSIS installer is produced.
* Updated NSIS installer settings to:
  - Disable one-click installation and allow users to change the installation directory.
  - Standardize the artifact name format to `${productName}-v${version}-x64.${ext}`.
  - Include the `LICENSE` file in the installer.