### PR TITLE
feat: Cap undo history to 50 entries

### DIFF
--- a/src/lib/useHistory.ts
+++ b/src/lib/useHistory.ts
@@ -1,11 +1,14 @@
 import Konva from "konva";
 
+const MAX_HISTORY = 50;
+
 export function useHistory(getDrawLayer: () => Konva.Layer) {
 	const undoStack: Konva.Node[] = [];
 	const redoStack: Konva.Node[] = [];
 
 	function saveSnapshot(node: Konva.Node) {
 		undoStack.push(node);
+		if (undoStack.length > MAX_HISTORY) undoStack.shift();
 		redoStack.length = 0;
 	}
 


### PR DESCRIPTION
This pull request adds a limit to the number of undo history states that can be stored in the `useHistory` hook to prevent excessive memory usage.