### PR TITLE
fix: Eraser doesnt follow the selected brush size

### DIFF
--- a/src/lib/useTools.ts
+++ b/src/lib/useTools.ts
@@ -30,7 +30,7 @@ export function useTools(
 			currentShape = new Konva.Line({
 				points: [pos.x, pos.y, pos.x, pos.y],
 				stroke: tool === "eraser" ? "#ffffff" : color,
-				strokeWidth: tool === "eraser" ? size * 2 : size,
+				strokeWidth: size,
 				tension: tool === "brush" ? 0.4 : 0,
 				lineCap: "round",
 				lineJoin: "round",


### PR DESCRIPTION
This pull request makes a small change to the `useTools` hook to standardize the stroke width behavior for the eraser tool. Now, the `strokeWidth` for the eraser is set to the same value as other tools, instead of being doubled (fixes #62).

<img width="1920" height="1022" alt="image" src="https://github.com/user-attachments/assets/106bfe40-e1de-4aa3-bd67-e03ddd429481" />

*Eraser erasing the black paint (white stroke on left), Paint tool on yellow color (yellow stroke on right)*