### PR TITLE
feat: Remove reload option in menu bar including its keybind

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -69,7 +69,6 @@ function createWindow() {
 		{
 			label: "View",
 			submenu: [
-				{ role: "reload" },
 				...(!app.isPackaged ? [{ role: "toggleDevTools" }] : []),
 				{ type: "separator" },
 				{ role: "resetZoom" },


### PR DESCRIPTION
This PR makes a small change to the `electron/main.js` file by removing the "reload" option from the "View" menu (this includes the Ctrl+R keybind). This will prevent users from accidentally reloading the application causing them to lose their work.