### PR TITLE
feat: Remove page reload and keybind

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -73,7 +73,6 @@ function createWindow() {
 		{
 			label: "View",
 			submenu: [
-				{ role: "reload" },
 				...(!app.isPackaged ? [{ role: "toggleDevTools" }] : []),
 				{ type: "separator" },
 				{ role: "resetZoom" },


### PR DESCRIPTION
This PR makes a minor update by removing the "reload" option from the "View" submenu. This change prevent accidental reloads during use.