### PR TITLE
feat: Open GitHub issues from 'Report an Issue' menu

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -86,6 +86,8 @@ function createWindow() {
 			submenu: [
 				{
 					label: "Report an Issue",
+					click: () =>
+						shell.openExternal("https://github.com/jrwnnnn/re-color/issues"),
 				},
 				{
 					label: "About Re:Color",


### PR DESCRIPTION
This pull request makes a minor update to the application menu by adding a "Report an Issue" option that opens the project's GitHub issues page in the user's browser.